### PR TITLE
fix: navbar auto show is too sensitive

### DIFF
--- a/src/components/Navbar/AutoHideWrapper.tsx
+++ b/src/components/Navbar/AutoHideWrapper.tsx
@@ -6,6 +6,8 @@ import React, { useEffect, useState, memo } from 'react'
 import Dialog from '@mui/material/Dialog'
 import Grow from '@mui/material/Grow'
 
+let timeout: NodeJS.Timeout
+
 function NavbarAutoHideWrapper({
   children,
 }: {
@@ -15,9 +17,13 @@ function NavbarAutoHideWrapper({
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent): void => {
-      if (event.clientY === 0 && !isShow) {
-        setIsShow(true)
-      }
+      clearTimeout(timeout)
+
+      timeout = setTimeout(() => {
+        if (event.clientY === 0 && !isShow) {
+          setIsShow(true)
+        }
+      }, 50)
     }
 
     window.addEventListener('mousemove', handleMouseMove)


### PR DESCRIPTION
solution:
debounce calling checker for 50ms, so it will show after user cursor is stay at y: 0 for 50ms